### PR TITLE
Injects the stored procedure ClearData to drop existing volatile data each night

### DIFF
--- a/EzPay.Model/EZPayContext.cs
+++ b/EzPay.Model/EZPayContext.cs
@@ -181,5 +181,24 @@
                         .HasMaxLength(3);
                 });
         }
+
+        /// <summary>
+        /// <inheritdoc />
+        /// </summary>
+        public EzPayContext()
+        {
+            Database.ExecuteSqlCommand(
+                @"
+            DROP PROCEDURE IF EXISTS dbo.ClearData");
+            Database.ExecuteSqlCommand(
+                @"
+            CREATE PROCEDURE [dbo].[ClearData]
+            AS
+            BEGIN
+                DELETE FROM Payments;
+                DELETE FROM Bills;
+                DELETE FROM Settlements;
+            END");
+        }
     }
 }


### PR DESCRIPTION
Stored Procedure ClearData drops data from Settlements/Bills/Payments, to be run nightly before importing new data.